### PR TITLE
Removes marginTop from calendarControls

### DIFF
--- a/CalendarIOS.js
+++ b/CalendarIOS.js
@@ -231,7 +231,6 @@ var styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     margin: 10,
-    marginTop: 30
   },
   controlButton: {
     flex: 1,


### PR DESCRIPTION
This allows the developer to decide how much padding to add to the top.
