### PR TITLE
provided reference (to start date of new month shown) within props.on…

### DIFF
--- a/CalendarIOS.js
+++ b/CalendarIOS.js
@@ -186,13 +186,13 @@ var Calendar = React.createClass({
   _onPrev(){
     this._prependMonth();
     this._scrollToItem(VIEW_INDEX);
-    this.props.onTouchPrev && this.props.onTouchPrev();
+    this.props.onTouchPrev && this.props.onTouchPrev(this.state.calendarDates[VIEW_INDEX]);
   },
 
   _onNext(){
     this._appendMonth();
     this._scrollToItem(VIEW_INDEX);
-    this.props.onTouchNext && this.props.onTouchNext();
+    this.props.onTouchNext && this.props.onTouchNext(this.state.calendarDates[VIEW_INDEX]);
   },
 
   _scrollToItem(itemIndex) {


### PR DESCRIPTION
Provided reference (to start date of new month shown) within `props.onPrev` and `props.onNext` functions. Purpose of this change is to inform the client program (of react-native-calendar) of the new month that is being displayed after "Next" or "Prev" buttons are pressed...
