### PR TITLE
onDateIsEnabled callback to determine if date is selectable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Portrait mode only
   prevButtonText={'Prev'}           // Text for previous button. Default: 'Prev'
   nextButtonText={'Next'}           // Text for next button. Default: 'Next'
   onDateSelect={(date) => this.onDateSelect(date)} // Callback after date selection
+  onDateIsEnabled={(date) => this.decideIfDateIsEnabled(date)} // Optional callback to determine if a specific date is selectable
   onTouchPrev={this.onTouchPrev}    // Callback for prev touch event
   onTouchNext={this.onTouchNext}    // Callback for next touch event
   onSwipePrev={this.onSwipePrev}    // Callback for back swipe event

--- a/components/Calendar.js
+++ b/components/Calendar.js
@@ -14,6 +14,7 @@ import styles from './styles';
 
 const DEVICE_WIDTH = Dimensions.get('window').width;
 const VIEW_INDEX = 2;
+const DATE_FORMAT = 'YYYY-MM-DD';
 
 export default class Calendar extends Component {
 
@@ -28,6 +29,7 @@ export default class Calendar extends Component {
     eventDates: PropTypes.array,
     monthNames: PropTypes.array,
     nextButtonText: PropTypes.string,
+    onDateIsEnabled: PropTypes.func,
     onDateSelect: PropTypes.func,
     onSwipeNext: PropTypes.func,
     onSwipePrev: PropTypes.func,
@@ -53,7 +55,7 @@ export default class Calendar extends Component {
     prevButtonText: 'Prev',
     scrollEnabled: false,
     showControls: false,
-    startDate: moment().format('YYYY-MM-DD'),
+    startDate: moment().format(DATE_FORMAT),
     titleFormat: 'MMMM YYYY',
     today: moment(),
     weekStart: 1,
@@ -135,7 +137,8 @@ export default class Calendar extends Component {
       renderIndex = 0,
       weekRows = [],
       days = [],
-      startOfArgMonthMoment = argMoment.startOf('month');
+      startOfArgMonthMoment = argMoment.startOf('month')
+      hasIsEnabledCallback = 'function' === typeof this.props.onDateIsEnabled;
 
     const
       selectedMoment = moment(this.state.selectedMoment),
@@ -157,6 +160,10 @@ export default class Calendar extends Component {
       const isoWeekday = (renderIndex + weekStart) % 7;
 
       if (dayIndex >= 0 && dayIndex < argMonthDaysCount) {
+        const isEnabled = hasIsEnabledCallback
+          ? this.props.onDateIsEnabled(moment(startOfArgMonthMoment).set('date', dayIndex + 1).format(DATE_FORMAT))
+          : true;
+
         days.push((
           <Day
             startOfMonth={startOfArgMonthMoment}
@@ -168,6 +175,7 @@ export default class Calendar extends Component {
             caption={`${dayIndex + 1}`}
             isToday={argMonthIsToday && (dayIndex === todayIndex)}
             isSelected={selectedMonthIsArg && (dayIndex === selectedIndex)}
+            isEnabled={isEnabled}
             hasEvent={events && events[dayIndex] === true}
             usingEvents={this.props.eventDates.length > 0}
             customStyle={this.props.customStyle}

--- a/components/Day.js
+++ b/components/Day.js
@@ -18,6 +18,7 @@ export default class Day extends Component {
     customStyle: PropTypes.object,
     filler: PropTypes.bool,
     hasEvent: PropTypes.bool,
+    isEnabled: PropTypes.bool,
     isSelected: PropTypes.bool,
     isToday: PropTypes.bool,
     isWeekend: PropTypes.bool,
@@ -27,26 +28,28 @@ export default class Day extends Component {
 
   dayCircleStyle = (isWeekend, isSelected, isToday) => {
     const { customStyle } = this.props;
-    const dayCircleStyle = [styles.dayCircleFiller, customStyle.dayCircleFiller && customStyle.dayCircleFiller];
+    const dayCircleStyle = [styles.dayCircleFiller, customStyle.dayCircleFiller];
 
     if (isSelected && !isToday) {
-      dayCircleStyle.push(styles.selectedDayCircle, customStyle.selectedDayCircle && customStyle.selectedDayCircle);
+      dayCircleStyle.push(styles.selectedDayCircle, customStyle.selectedDayCircle);
     } else if (isSelected && isToday) {
-      dayCircleStyle.push(styles.currentDayCircle, customStyle.currentDayCircle && customStyle.currentDayCircle);
+      dayCircleStyle.push(styles.currentDayCircle, customStyle.currentDayCircle);
     }
     return dayCircleStyle;
   }
 
-  dayTextStyle = (isWeekend, isSelected, isToday) => {
+  dayTextStyle = (isWeekend, isSelected, isToday, isEnabled) => {
     const { customStyle } = this.props;
     const dayTextStyle = [styles.day, customStyle.day];
 
-    if (isToday && !isSelected) {
-      dayTextStyle.push(styles.currentDayText, customStyle.currentDayText && customStyle.currentDayText);
+    if (!isEnabled) {
+      dayTextStyle.push(styles.disabledDayText, customStyle.disabledDayText);
+    } else if (isToday && !isSelected) {
+      dayTextStyle.push(styles.currentDayText, customStyle.currentDayText);
     } else if (isToday || isSelected) {
-      dayTextStyle.push(styles.selectedDayText, customStyle.selectedDayText && customStyle.selectedDayText);
+      dayTextStyle.push(styles.selectedDayText, customStyle.selectedDayText);
     } else if (isWeekend) {
-      dayTextStyle.push(styles.weekendDayText, customStyle.weekendDayText && customStyle.weekendDayText);
+      dayTextStyle.push(styles.weekendDayText, customStyle.weekendDayText);
     }
     return dayTextStyle;
   }
@@ -56,9 +59,10 @@ export default class Day extends Component {
     const {
       filler,
       hasEvent,
-      isWeekend,
+      isEnabled,
       isSelected,
       isToday,
+      isWeekend,
       usingEvents,
     } = this.props;
 
@@ -71,10 +75,10 @@ export default class Day extends Component {
         </TouchableWithoutFeedback>
       )
     : (
-      <TouchableOpacity onPress={this.props.onPress}>
+      <TouchableOpacity disabled={!isEnabled} onPress={this.props.onPress}>
         <View style={[styles.dayButton, customStyle.dayButton]}>
           <View style={this.dayCircleStyle(isWeekend, isSelected, isToday)}>
-            <Text style={this.dayTextStyle(isWeekend, isSelected, isToday)}>{caption}</Text>
+            <Text style={this.dayTextStyle(isWeekend, isSelected, isToday, isEnabled)}>{caption}</Text>
           </View>
           {usingEvents &&
             <View style={[

--- a/components/styles.js
+++ b/components/styles.js
@@ -94,6 +94,9 @@ const styles = StyleSheet.create({
   weekendDayText: {
     color: '#cccccc',
   },
+  disabledDayText: {
+    color: '#eee',
+  },
 });
 
 export default styles;

--- a/example/App.js
+++ b/example/App.js
@@ -51,6 +51,7 @@ class App extends Component {
           titleFormat={'MMMM YYYY'}
           prevButtonText={'Prev'}
           nextButtonText={'Next'}
+          onDateIsEnabled={(date) => !/\d{4}-\d{2}-15/.test(date)} // disable 15th of the month
           onDateSelect={(date) => this.setState({ selectedDate: date })}
           onTouchPrev={() => console.log('Back TOUCH')}     // eslint-disable-line no-console
           onTouchNext={() => console.log('Forward TOUCH')}  // eslint-disable-line no-console

--- a/example/package.json
+++ b/example/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "react": "^15.1.0",
-    "react-native": "^0.27.0-rc2",
-    "react-native-calendar": "github:christopherdro/react-native-calendar#revamp"
+    "react-native": "^0.27.0",
+    "react-native-calendar": "file:../"
   }
 }


### PR DESCRIPTION
I needed this for a project I'm working on. Basically I needed only past dates to be selectable and for future dates to not even be clickable. I implemented this by providing the component with a callback to check whether a specific date is enabled. If it isn't enabled then it won't be wrapped in a `<TouchableWithoutFeedback />` and a new `disabledDayText` style is applied.

This may not fit with your plans for this component but like I said, I needed this for a project and decided to implement it this way.

Also did some cleanup, for example `CalendarIOS` still had `_dayTextStyle()` and `_dayCircleStyle()` methods which were going unused. I assumed it was old code and removed it.
