### PR TITLE
fixed require ReactPropTypes bug

### DIFF
--- a/CalendarIOS.js
+++ b/CalendarIOS.js
@@ -1,7 +1,7 @@
 'use strict';
 
 let React = require('react-native');
-let PropTypes = require('ReactPropTypes');
+// let PropTypes = require('ReactPropTypes');
 let moment = require('moment');
 let _ = require('lodash');
 
@@ -12,6 +12,7 @@ let {
   Text,
   TouchableOpacity,
   TouchableWithoutFeedback,
+  PropTypes,
   View
 } = React;
 


### PR DESCRIPTION
Fixed error: `Unable to resolve module ReactPropTypes from /XXX. Invalid directory XX/node_modules/ReactPropTypes`
