### PR TITLE
Added possibility to style day when there is an event

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ Portrait mode only
 - currentDayText
 - selectedDayCircle
 - selectedDayText
-- weekendDayText
+- weekendDayText  
+- hasEventCircle
+- hasEventText
 
 
 ## TODOS

--- a/components/Day.js
+++ b/components/Day.js
@@ -36,12 +36,12 @@ export default class Day extends Component {
     }
 
     if (hasEvent) {
-      dayCircleStyle.push(styles.hasEvent, customStyle.hasEvent && customStyle.hasEvent)
+      dayCircleStyle.push(styles.hasEventCircle, customStyle.hasEventCircle && customStyle.hasEventCircle)
     }
     return dayCircleStyle;
   }
 
-  dayTextStyle = (isWeekend, isSelected, isToday) => {
+  dayTextStyle = (isWeekend, isSelected, isToday, hasEvent) => {
     const { customStyle } = this.props;
     const dayTextStyle = [styles.day, customStyle.day];
 
@@ -51,6 +51,10 @@ export default class Day extends Component {
       dayTextStyle.push(styles.selectedDayText, customStyle.selectedDayText && customStyle.selectedDayText);
     } else if (isWeekend) {
       dayTextStyle.push(styles.weekendDayText, customStyle.weekendDayText && customStyle.weekendDayText);
+    }
+
+    if (hasEvent) {
+      dayTextStyle.push(styles.hasEventText, customStyle.hasEventText && customStyle.hasEventText)
     }
     return dayTextStyle;
   }
@@ -78,7 +82,7 @@ export default class Day extends Component {
       <TouchableOpacity onPress={this.props.onPress}>
         <View style={[styles.dayButton, customStyle.dayButton]}>
           <View style={this.dayCircleStyle(isWeekend, isSelected, isToday, hasEvent)}>
-            <Text style={this.dayTextStyle(isWeekend, isSelected, isToday)}>{caption}</Text>
+            <Text style={this.dayTextStyle(isWeekend, isSelected, isToday, hasEvent)}>{caption}</Text>
           </View>
           {usingEvents &&
             <View style={[

--- a/components/Day.js
+++ b/components/Day.js
@@ -25,7 +25,7 @@ export default class Day extends Component {
     usingEvents: PropTypes.bool,
   }
 
-  dayCircleStyle = (isWeekend, isSelected, isToday) => {
+  dayCircleStyle = (isWeekend, isSelected, isToday, hasEvent) => {
     const { customStyle } = this.props;
     const dayCircleStyle = [styles.dayCircleFiller, customStyle.dayCircleFiller && customStyle.dayCircleFiller];
 
@@ -33,6 +33,10 @@ export default class Day extends Component {
       dayCircleStyle.push(styles.selectedDayCircle, customStyle.selectedDayCircle && customStyle.selectedDayCircle);
     } else if (isSelected && isToday) {
       dayCircleStyle.push(styles.currentDayCircle, customStyle.currentDayCircle && customStyle.currentDayCircle);
+    }
+
+    if (hasEvent) {
+      dayCircleStyle.push(styles.hasEvent, customStyle.hasEvent && customStyle.hasEvent)
     }
     return dayCircleStyle;
   }
@@ -73,7 +77,7 @@ export default class Day extends Component {
     : (
       <TouchableOpacity onPress={this.props.onPress}>
         <View style={[styles.dayButton, customStyle.dayButton]}>
-          <View style={this.dayCircleStyle(isWeekend, isSelected, isToday)}>
+          <View style={this.dayCircleStyle(isWeekend, isSelected, isToday, hasEvent)}>
             <Text style={this.dayTextStyle(isWeekend, isSelected, isToday)}>{caption}</Text>
           </View>
           {usingEvents &&

--- a/components/styles.js
+++ b/components/styles.js
@@ -87,6 +87,8 @@ const styles = StyleSheet.create({
   selectedDayCircle: {
     backgroundColor: 'black',
   },
+  hasEvent: {
+  },
   selectedDayText: {
     color: 'white',
     fontWeight: 'bold',

--- a/components/styles.js
+++ b/components/styles.js
@@ -87,7 +87,9 @@ const styles = StyleSheet.create({
   selectedDayCircle: {
     backgroundColor: 'black',
   },
-  hasEvent: {
+  hasEventCircle: {
+  },
+  hasEventText: {
   },
   selectedDayText: {
     color: 'white',


### PR DESCRIPTION
Hi, 

Here is an other way to show event at the selected dates instead of using the indicator below the date.

<img src="https://cloud.githubusercontent.com/assets/14168629/16384492/59de0042-3c89-11e6-936d-3a590e7c14cf.jpg" height="500" width="300" >

Don't forget to put the following customStyle in the Calendar customStyle props : 

```
  const customStyle = {
      selectedDayCircle: { backgroundColor: 'transparent' },
      selectedDayText: { color: 'black' },
      eventIndicator: { backgroundColor: 'transparent' },
      eventIndicatorFiller: { height: 0, width: 0, marginTop: 0, borderRadius: 0 },
      hasEventCircle: { backgroundColor: 'orange' },
      hasEventText: { color: 'white' }
    }
```

Thank's :)
