### PR TITLE
Add customize scroll width functionality

### DIFF
--- a/components/Calendar.js
+++ b/components/Calendar.js
@@ -45,6 +45,7 @@ export default class Calendar extends Component {
 
   static defaultProps = {
     customStyle: {},
+    width: DEVICE_WIDTH,
     dayHeadings: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
     eventDates: [],
     monthNames: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
@@ -110,7 +111,7 @@ export default class Calendar extends Component {
   }
 
   scrollToItem(itemIndex) {
-    const scrollToX = itemIndex * DEVICE_WIDTH;
+    const scrollToX = itemIndex * this.props.width;
     if (this.props.scrollEnabled) {
       this._calendar.scrollTo({ y: 0, x: scrollToX, animated: false });
     }
@@ -118,7 +119,7 @@ export default class Calendar extends Component {
 
   scrollEnded(event) {
     const position = event.nativeEvent.contentOffset.x;
-    const currentPage = position / DEVICE_WIDTH;
+    const currentPage = position / this.props.width;
     const newMoment = moment(this.state.currentMonthMoment).add(currentPage - VIEW_INDEX, 'month');
     this.setState({ currentMonthMoment: newMoment });
 


### PR DESCRIPTION
This update allows users to customize the width of their calendar by adding a "width" attribute on the component to match scroll width to their set monthContainer width value. Users will additionally have to set dayButton and dayButtonFiller widths to (custom width / 7).
