### PR TITLE
New PropTypes check

### DIFF
--- a/components/Calendar.js
+++ b/components/Calendar.js
@@ -28,8 +28,8 @@ export default class Calendar extends Component {
     eventDates: PropTypes.array,
     monthNames: PropTypes.array,
     nextButtonText: PropTypes.oneOfType([
-      Proptypes.string,
-      Proptypes.object
+      PropTypes.string,
+      PropTypes.object
     ]),
     onDateSelect: PropTypes.func,
     onSwipeNext: PropTypes.func,
@@ -37,8 +37,8 @@ export default class Calendar extends Component {
     onTouchNext: PropTypes.func,
     onTouchPrev: PropTypes.func,
     prevButtonText: PropTypes.oneOfType([
-      Proptypes.string,
-      Proptypes.object
+      PropTypes.string,
+      PropTypes.object
     ]),
     scrollEnabled: PropTypes.bool,
     selectedDate: PropTypes.any,

--- a/components/Calendar.js
+++ b/components/Calendar.js
@@ -27,13 +27,19 @@ export default class Calendar extends Component {
     dayHeadings: PropTypes.array,
     eventDates: PropTypes.array,
     monthNames: PropTypes.array,
-    nextButtonText: PropTypes.string,
+    nextButtonText: PropTypes.oneOfType([
+      Proptypes.string,
+      Proptypes.object
+    ]),
     onDateSelect: PropTypes.func,
     onSwipeNext: PropTypes.func,
     onSwipePrev: PropTypes.func,
     onTouchNext: PropTypes.func,
     onTouchPrev: PropTypes.func,
-    prevButtonText: PropTypes.string,
+    prevButtonText: PropTypes.oneOfType([
+      Proptypes.string,
+      Proptypes.object
+    ]),
     scrollEnabled: PropTypes.bool,
     selectedDate: PropTypes.any,
     showControls: PropTypes.bool,


### PR DESCRIPTION
This will fix the warnings you get if you send anything else than text to `nextButtonText` and `prevButtonText`. 
In a project I work on currently we use the [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons) to send in icons instead of text and it works perfekt.
I haven't got it to work with images but this might be enough since [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons) offers alot of icons to choose from.

This might solve #32 ??

Hope it helps.
