### PR TITLE
date could be null to deselect the current day.

### DIFF
--- a/components/Calendar.js
+++ b/components/Calendar.js
@@ -94,7 +94,7 @@ export default class Calendar extends Component {
 
   selectDate(date) {
     this.setState({ selectedMoment: date });
-    this.props.onDateSelect && this.props.onDateSelect(date.format());
+    this.props.onDateSelect && this.props.onDateSelect(date ? date.format(): null );
   }
 
   onPrev = () => {


### PR DESCRIPTION
i am using the ref to programmatically  set selected dates. there is a bug if i try to set null as the selected day to remove from the calendar the selected day. 
