### PR TITLE
Fixed ScrollView initial render bug on Android

### DIFF
--- a/components/Calendar.js
+++ b/components/Calendar.js
@@ -67,7 +67,8 @@ export default class Calendar extends Component {
   };
 
   componentDidMount() {
-    this.scrollToItem(VIEW_INDEX);
+    // fixes initial scrolling bug on Android
+    setTimeout(() => this.scrollToItem(VIEW_INDEX), 0)
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
On Android, the calendar does not start with the correct month when using scrollEnabled.
See issue #43 
