### PR TITLE
Fix bug when using selectedDate.

### DIFF
--- a/components/Calendar.js
+++ b/components/Calendar.js
@@ -73,6 +73,12 @@ export default class Calendar extends Component {
   componentDidUpdate() {
     this.scrollToItem(VIEW_INDEX);
   }
+  
+  componentWillReceiveProps(props) {
+    if (props.selectedDate) {
+      this.setState({selectedMoment: props.selectedDate});
+    }
+  }
 
   getMonthStack(currentMonth) {
     if (this.props.scrollEnabled) {


### PR DESCRIPTION
@christopherdro @coderdave   When using selectedDate it renders and highlights the date for current Month, but when we `Press` or `Swipe` to the `Next` or `Prev` month, the selectedDate doesn't get highlighted.
See issue #65 
So, this commit fixes this bug.
