### PR TITLE
Determine height based on number of weeks in current month

### DIFF
--- a/components/Calendar.js
+++ b/components/Calendar.js
@@ -15,6 +15,12 @@ import styles from './styles';
 const DEVICE_WIDTH = Dimensions.get('window').width;
 const VIEW_INDEX = 2;
 
+function getNumberOfWeeks(month) {
+  const firstWeek = moment(month).startOf('month').week();
+  const lastWeek = moment(month).endOf('month').week();
+  return lastWeek - firstWeek + 1;
+}
+
 export default class Calendar extends Component {
 
   state = {
@@ -69,17 +75,10 @@ export default class Calendar extends Component {
     weekStart: 1,
   };
 
-  static getNumberOfWeeks(month) {
-    const firstWeek = moment(month).startOf('month').week();
-    const lastWeek = moment(month).endOf('month').week();
-    return lastWeek - firstWeek + 1;
-  }
-
   constructor(props) {
     super(props);
 
     this.onWeekRowLayout = this.onWeekRowLayout.bind(this);
-    this.shouldUpdateHeight = true;
   }
 
   componentDidMount() {
@@ -171,10 +170,8 @@ export default class Calendar extends Component {
   }
 
   onWeekRowLayout(event) {
-    if (this.state.rowHeight !== event.nativeEvent.layout.height && this.shouldUpdateHeight) {
-      this.shouldUpdateHeight = false;
+    if (this.state.rowHeight !== event.nativeEvent.layout.height) {
       this.setState({ rowHeight: event.nativeEvent.layout.height });
-      setTimeout(() => { this.shouldUpdateHeight = true; }, 200);
     }
   }
 
@@ -229,7 +226,7 @@ export default class Calendar extends Component {
         weekRows.push(
           <View
             key={weekRows.length}
-            onLayout={this.onWeekRowLayout}
+            onLayout={weekRows.length ? undefined : this.onWeekRowLayout}
             style={[styles.weekRow, this.props.customStyle.weekRow]}
           >
             {days}
@@ -306,7 +303,7 @@ export default class Calendar extends Component {
   render() {
     const calendarDates = this.getMonthStack(this.state.currentMonthMoment);
     const eventDatesMap = this.prepareEventDates(this.props.eventDates, this.props.events);
-    const numOfWeeks = Calendar.getNumberOfWeeks(this.state.currentMonthMoment);
+    const numOfWeeks = getNumberOfWeeks(this.state.currentMonthMoment);
 
     return (
       <View style={[styles.calendarContainer, this.props.customStyle.calendarContainer]}>

--- a/components/Calendar.js
+++ b/components/Calendar.js
@@ -75,12 +75,6 @@ export default class Calendar extends Component {
     weekStart: 1,
   };
 
-  constructor(props) {
-    super(props);
-
-    this.onWeekRowLayout = this.onWeekRowLayout.bind(this);
-  }
-
   componentDidMount() {
     // fixes initial scrolling bug on Android
     setTimeout(() => this.scrollToItem(VIEW_INDEX), 0)
@@ -169,7 +163,7 @@ export default class Calendar extends Component {
     }
   }
 
-  onWeekRowLayout(event) {
+  onWeekRowLayout = (event) => {
     if (this.state.rowHeight !== event.nativeEvent.layout.height) {
       this.setState({ rowHeight: event.nativeEvent.layout.height });
     }


### PR DESCRIPTION
This is for https://github.com/christopherdro/react-native-calendar/issues/40.
Currently for scrollenabled, if there is one month with 6 weeks instead of 5 weeks, the scrollView will have height of 6 weeks in order to be able to contain all its children views. This change forces the scrollview to have the height of the current monthContainer instead of the month with biggest height.

Fixing the height of the daybutton so that it is easier to determine the height of the month container.
