### PR TITLE
Remove the usingEvents to avoid page switch flash

### DIFF
--- a/components/Calendar.js
+++ b/components/Calendar.js
@@ -194,7 +194,6 @@ export default class Calendar extends Component {
             isToday={argMonthIsToday && (dayIndex === todayIndex)}
             isSelected={selectedMonthIsArg && (dayIndex === selectedIndex)}
             event={events && events[dayIndex]}
-            usingEvents={this.props.eventDates.length > 0}
             customStyle={this.props.customStyle}
           />
         ));

--- a/components/Day.js
+++ b/components/Day.js
@@ -22,7 +22,6 @@ export default class Day extends Component {
     isToday: PropTypes.bool,
     isWeekend: PropTypes.bool,
     onPress: PropTypes.func,
-    usingEvents: PropTypes.bool,
   }
 
   dayCircleStyle = (isWeekend, isSelected, isToday, event) => {
@@ -67,7 +66,6 @@ export default class Day extends Component {
       isWeekend,
       isSelected,
       isToday,
-      usingEvents,
     } = this.props;
 
     return filler
@@ -84,7 +82,7 @@ export default class Day extends Component {
           <View style={this.dayCircleStyle(isWeekend, isSelected, isToday, event)}>
             <Text style={this.dayTextStyle(isWeekend, isSelected, isToday, event)}>{caption}</Text>
           </View>
-          {usingEvents &&
+          {
             <View style={[
               styles.eventIndicatorFiller,
               customStyle.eventIndicatorFiller,


### PR DESCRIPTION
Remove the usingEvents variable to avoid page flash (due to row height change) when switch from month with events to month without events.
