### PR TITLE
Allow changing the currently displayed month externally via a currentMonth prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Portrait mode only
 ## Usage
 ```javascript
 <Calendar
+  currentMonth={'2015-08-01'}       // Optional date to set the currently displayed month after initialization
   customStyle={{day: {fontSize: 15, textAlign: 'center'}}} // Customize any pre-defined styles
   dayHeadings={Array}               // Default: ['S', 'M', 'T', 'W', 'T', 'F', 'S']
   eventDates={['2015-07-01']}       // Optional array of moment() parseable dates that will show an event indicator

--- a/components/Calendar.js
+++ b/components/Calendar.js
@@ -23,6 +23,7 @@ export default class Calendar extends Component {
   };
 
   static propTypes = {
+    currentMonth: PropTypes.any,
     customStyle: PropTypes.object,
     dayHeadings: PropTypes.array,
     eventDates: PropTypes.array,
@@ -76,10 +77,13 @@ export default class Calendar extends Component {
   componentDidUpdate() {
     this.scrollToItem(VIEW_INDEX);
   }
-  
+
   componentWillReceiveProps(props) {
     if (props.selectedDate) {
       this.setState({selectedMoment: props.selectedDate});
+    }
+    if (props.currentMonth) {
+      this.setState({currentMonthMoment: moment(props.currentMonth)});
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-calendar",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Simple Calendar Component for React Native",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
I considered using the startDate prop itself to set the current month but went with currentMonth as the prop to set in case startDate is used in the future for setting actual start/end bounds on the calendar.

Please let me know if this all makes sense or if there is a better way to change the shown month from outside of the component. 🤗 