### PR TITLE
Disabled days - combined #97 #98

### DIFF
--- a/components/Calendar.js
+++ b/components/Calendar.js
@@ -141,7 +141,7 @@ export default class Calendar extends Component {
       const date = moment(disabled);
       const month = moment(date).startOf('month').format();
       parsedDates[month] = parsedDates[month] || {};
-      parsedDates[month][date.date() - 1] = {};
+      parsedDates[month][date.date() - 1] = true;
     });
 
     return parsedDates;
@@ -217,14 +217,8 @@ export default class Calendar extends Component {
       selectedIndex = moment(selectedMoment).date() - 1,
       selectedMonthIsArg = selectedMoment.isSame(argMoment, 'month');
 
-    const events = (eventsMap !== null)
-      ? eventsMap[argMoment.startOf('month').format()]
-      : null;
-
-    const disabledDates = (disabledDatesMap !== null)
-      ? disabledDatesMap[argMoment.startOf('month').format()]
-      : null;
-
+    const events = eventsMap[argMoment.startOf('month').format()] || {};
+    const disabledDates = disabledDatesMap[argMoment.startOf('month').format()] || {};
     const minDate = moment(this.props.minDate);
     const maxDate =  moment(this.props.maxDate);
 
@@ -232,50 +226,39 @@ export default class Calendar extends Component {
       const dayIndex = renderIndex - offset;
       const isoWeekday = (renderIndex + weekStart) % 7;
       const currentDate = moment(startOfArgMonthMoment).set('date', dayIndex + 1);
+      const caption = String(dayIndex + 1);
 
       if (dayIndex >= 0 && dayIndex < argMonthDaysCount) {
-        if(currentDate.isBetween(minDate, maxDate, 'day', '[]'))
+        const dayEnabled = !this.props.disabledDays.includes(isoWeekday);
+        const dateEnabled = currentDate.isBetween(minDate, maxDate, 'day', '[]') && !disabledDates[dayIndex];
+        if(dayEnabled && dateEnabled)
         {
-          const dayDisabled = this.props.disabledDays.includes(isoWeekday);
-          const dateDisabled = !!(disabledDates && disabledDates[dayIndex]);
-          if( !dayDisabled && !dateDisabled )
-          {
-            days.push((
-              <Day
-                startOfMonth={startOfArgMonthMoment}
-                key={`${renderIndex}`}
-                onPress={() => this.selectDate(currentDate)}
-                onLongPress={() => this.longPress(currentDate)}
-                caption={`${dayIndex + 1}`}
-                isToday={argMonthIsToday && (dayIndex === todayIndex)}
-                isSelected={selectedMonthIsArg && (dayIndex === selectedIndex)}
-                event={events && events[dayIndex]}
-                showEventIndicators={this.props.showEventIndicators}
-                customStyle={this.props.customStyle}
-              />
-            ));
-          } else {
-            days.push(<Day
-                        key={`${renderIndex}`}
-                        caption={`${dayIndex + 1}`}
-                        isToday={argMonthIsToday && (dayIndex === todayIndex)}
-                        showEventIndicators={this.props.showEventIndicators}
-                        disabled
-                        customStyle={this.props.customStyle}
-                        />);
-          }
+          days.push((
+            <Day
+              key={renderIndex}
+              onPress={() => this.selectDate(currentDate)}
+              onLongPress={() => this.longPress(currentDate)}
+              caption={caption}
+              isToday={argMonthIsToday && (dayIndex === todayIndex)}
+              isSelected={selectedMonthIsArg && (dayIndex === selectedIndex)}
+              event={events[dayIndex]}
+              showEventIndicators={this.props.showEventIndicators}
+              customStyle={this.props.customStyle}
+            />
+          ));
         } else {
-           days.push(<Day
-                        key={`${renderIndex}`}
-                        caption={`${dayIndex + 1}`}
-                        isToday={argMonthIsToday && (dayIndex === todayIndex)}
-                        showEventIndicators={this.props.showEventIndicators}
-                        disabled
-                        customStyle={this.props.customStyle}
-                        />);
+          days.push(
+            <Day
+              key={renderIndex}
+              caption={caption}
+              isToday={argMonthIsToday && (dayIndex === todayIndex)}
+              showEventIndicators={this.props.showEventIndicators}
+              disabled
+              customStyle={this.props.customStyle} />
+          );
         }
       } else {
-        days.push(<Day key={`${renderIndex}`} filler customStyle={this.props.customStyle} />);
+        days.push(<Day key={renderIndex} filler customStyle={this.props.customStyle} />);
       }
       if (renderIndex % 7 === 6) {
         weekRows.push(

--- a/components/Calendar.js
+++ b/components/Calendar.js
@@ -33,11 +33,14 @@ export default class Calendar extends Component {
     customStyle: PropTypes.object,
     dayHeadings: PropTypes.array,
     eventDates: PropTypes.array,
+    disabledDates: PropTypes.array,
+    disabledDays: PropTypes.array,
     monthNames: PropTypes.array,
     nextButtonText: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.object
     ]),
+    onLongPress: PropTypes.func,
     onDateSelect: PropTypes.func,
     onSwipeNext: PropTypes.func,
     onSwipePrev: PropTypes.func,
@@ -54,6 +57,8 @@ export default class Calendar extends Component {
     startDate: PropTypes.any,
     titleFormat: PropTypes.string,
     today: PropTypes.any,
+    minDate: PropTypes.any,
+    maxDate: PropTypes.any,
     weekStart: PropTypes.number,
   };
 
@@ -62,6 +67,8 @@ export default class Calendar extends Component {
     width: DEVICE_WIDTH,
     dayHeadings: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
     eventDates: [],
+    disabledDates: [],
+    disabledDays: [],
     monthNames: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
       'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
     nextButtonText: 'Next',
@@ -72,6 +79,8 @@ export default class Calendar extends Component {
     startDate: moment().format('YYYY-MM-DD'),
     titleFormat: 'MMMM YYYY',
     today: moment(),
+    minDate: moment(),
+    maxDate: moment().add(1,'year'),
     weekStart: 1,
   };
 
@@ -125,6 +134,18 @@ export default class Calendar extends Component {
     }
     return parsedDates;
   }
+  prepareDisabledDates(disabledDates) {
+    const parsedDates = {};
+
+    disabledDates.forEach(disabled => {
+      const date = moment(disabled);
+      const month = moment(date).startOf('month').format();
+      parsedDates[month] = parsedDates[month] || {};
+      parsedDates[month][date.date() - 1] = {};
+    });
+
+    return parsedDates;
+  }
 
   selectDate(date) {
     this.setState({ selectedMoment: date });
@@ -165,11 +186,11 @@ export default class Calendar extends Component {
 
   onWeekRowLayout = (event) => {
     if (this.state.rowHeight !== event.nativeEvent.layout.height) {
-      this.setState({ rowHeight: event.nativeEvent.layout.height });
-    }
+		this.setState({ rowHeight: event.nativeEvent.layout.height });
+	}
   }
 
-  renderMonthView(argMoment, eventsMap) {
+  renderMonthView(argMoment, eventsMap, disabledDatesMap) {
 
     let
       renderIndex = 0,
@@ -183,6 +204,8 @@ export default class Calendar extends Component {
       todayMoment = moment(this.props.today),
       todayIndex = todayMoment.date() - 1,
       argMonthDaysCount = argMoment.daysInMonth(),
+      argMomentYear = argMoment.format('YYYY'),
+      argMomentMonth = argMoment.format('M'),
       offset = (startOfArgMonthMoment.isoWeekday() - weekStart + 7) % 7,
       argMonthIsToday = argMoment.isSame(todayMoment, 'month'),
       selectedIndex = moment(selectedMoment).date() - 1,
@@ -192,27 +215,59 @@ export default class Calendar extends Component {
       ? eventsMap[argMoment.startOf('month').format()]
       : null;
 
+    const disabledDates = (disabledDatesMap !== null)
+      ? disabledDatesMap[argMoment.startOf('month').format()]
+      : null;
+
+
     do {
       const dayIndex = renderIndex - offset;
       const isoWeekday = (renderIndex + weekStart) % 7;
 
       if (dayIndex >= 0 && dayIndex < argMonthDaysCount) {
-        days.push((
-          <Day
-            startOfMonth={startOfArgMonthMoment}
-            isWeekend={isoWeekday === 0 || isoWeekday === 6}
-            key={`${renderIndex}`}
-            onPress={() => {
-              this.selectDate(moment(startOfArgMonthMoment).set('date', dayIndex + 1));
-            }}
-            caption={`${dayIndex + 1}`}
-            isToday={argMonthIsToday && (dayIndex === todayIndex)}
-            isSelected={selectedMonthIsArg && (dayIndex === selectedIndex)}
-            event={events && events[dayIndex]}
-            showEventIndicators={this.props.showEventIndicators}
-            customStyle={this.props.customStyle}
-          />
-        ));
+        if(moment(startOfArgMonthMoment).set('date', dayIndex + 1).isAfter(moment(this.props.minDate))
+            && moment(startOfArgMonthMoment).set('date', dayIndex + 1).isBefore(moment(this.props.maxDate)))
+        {
+          if(!this.props.disabledDays.includes(isoWeekday) && (!disabledDates || (disabledDates && !disabledDates[dayIndex])) )
+          {
+            days.push((
+              <Day
+                startOfMonth={startOfArgMonthMoment}
+                key={`${renderIndex}`}
+                onPress={() => {
+                  this.selectDate(moment(startOfArgMonthMoment).set('date', dayIndex + 1));
+                }}
+                onLongPress={ () => {
+                  this.props.onLongPress(moment(startOfArgMonthMoment).set('date', dayIndex + 1).format());
+                }}
+                caption={`${dayIndex + 1}`}
+                isToday={argMonthIsToday && (dayIndex === todayIndex)}
+                isSelected={selectedMonthIsArg && (dayIndex === selectedIndex)}
+                event={events && events[dayIndex]}
+                showEventIndicators={this.props.showEventIndicators}
+                customStyle={this.props.customStyle}
+              />
+            ));
+          } else {
+            days.push(<Day 
+                        key={`${renderIndex}`} 
+                        caption={`${dayIndex + 1}`}
+                        isToday={argMonthIsToday && (dayIndex === todayIndex)}
+                        showEventIndicators={this.props.showEventIndicators}
+                        disabled 
+                        customStyle={this.props.customStyle} 
+                        />);
+          }
+        } else {
+           days.push(<Day 
+                        key={`${renderIndex}`} 
+                        caption={`${dayIndex + 1}`}
+                        isToday={argMonthIsToday && (dayIndex === todayIndex)}
+                        showEventIndicators={this.props.showEventIndicators}
+                        disabled 
+                        customStyle={this.props.customStyle} 
+                        />);
+        }
       } else {
         days.push(<Day key={`${renderIndex}`} filler customStyle={this.props.customStyle} />);
       }
@@ -243,9 +298,7 @@ export default class Calendar extends Component {
       headings.push(
         <Text
           key={i}
-          style={j === 0 || j === 6 ?
-            [styles.weekendHeading, this.props.customStyle.weekendHeading] :
-            [styles.dayHeading, this.props.customStyle.dayHeading]}
+          style={[styles.dayHeading, this.props.customStyle.dayHeading]}
         >
           {this.props.dayHeadings[j]}
         </Text>
@@ -260,7 +313,6 @@ export default class Calendar extends Component {
   }
 
   renderTopBar() {
-    let localizedMonth = this.props.monthNames[this.state.currentMonthMoment.month()];
     return this.props.showControls
     ? (
         <View style={[styles.calendarControls, this.props.customStyle.calendarControls]}>
@@ -273,7 +325,7 @@ export default class Calendar extends Component {
             </Text>
           </TouchableOpacity>
           <Text style={[styles.title, this.props.customStyle.title]}>
-            {this.state.currentMonthMoment.format(this.props.titleFormat)}
+        	{this.state.currentMonthMoment.format(this.props.titleFormat)}
           </Text>
           <TouchableOpacity
             style={[styles.controlButton, this.props.customStyle.controlButton]}
@@ -288,7 +340,7 @@ export default class Calendar extends Component {
     : (
       <View style={[styles.calendarControls, this.props.customStyle.calendarControls]}>
         <Text style={[styles.title, this.props.customStyle.title]}>
-          {this.state.currentMonthMoment.format(this.props.titleFormat)}
+        	{this.state.currentMonthMoment.format(this.props.titleFormat)}
         </Text>
       </View>
     );
@@ -297,7 +349,8 @@ export default class Calendar extends Component {
   render() {
     const calendarDates = this.getMonthStack(this.state.currentMonthMoment);
     const eventDatesMap = this.prepareEventDates(this.props.eventDates, this.props.events);
-    const numOfWeeks = getNumberOfWeeks(this.state.currentMonthMoment);
+    const numOfWeeks = getNumberOfWeeks(this.state.currentMonthMoment); 
+    const disabledDatesMap = this.prepareDisabledDates(this.props.disabledDates);
 
     return (
       <View style={[styles.calendarContainer, this.props.customStyle.calendarContainer]}>
@@ -314,15 +367,15 @@ export default class Calendar extends Component {
             showsHorizontalScrollIndicator={false}
             automaticallyAdjustContentInsets
             onMomentumScrollEnd={(event) => this.scrollEnded(event)}
-            style={{
-              height: this.state.rowHeight ? this.state.rowHeight * numOfWeeks : null,
-            }}
+            style={{ 
+			   height: this.state.rowHeight ? this.state.rowHeight * numOfWeeks : null, 
+			}}
           >
-            {calendarDates.map((date) => this.renderMonthView(moment(date), eventDatesMap))}
+            {calendarDates.map((date) => this.renderMonthView(moment(date), eventDatesMap, disabledDatesMap))}
           </ScrollView>
           :
           <View ref={calendar => this._calendar = calendar}>
-            {calendarDates.map((date) => this.renderMonthView(moment(date), eventDatesMap))}
+            {calendarDates.map((date) => this.renderMonthView(moment(date), eventDatesMap, disabledDatesMap))}
           </View>
         }
       </View>

--- a/components/Calendar.js
+++ b/components/Calendar.js
@@ -186,8 +186,8 @@ export default class Calendar extends Component {
 
   onWeekRowLayout = (event) => {
     if (this.state.rowHeight !== event.nativeEvent.layout.height) {
-		this.setState({ rowHeight: event.nativeEvent.layout.height });
-	}
+	  this.setState({ rowHeight: event.nativeEvent.layout.height });
+    }
   }
 
   renderMonthView(argMoment, eventsMap, disabledDatesMap) {

--- a/components/Calendar.js
+++ b/components/Calendar.js
@@ -154,6 +154,10 @@ export default class Calendar extends Component {
     this.props.onDateSelect && this.props.onDateSelect(date ? date.format(): null );
   }
 
+  longPress(date) {
+      this.props.onLongPress && this.props.onLongPress(date ? date.format(): null );
+  }
+
   onPrev = () => {
     const newMoment = moment(this.state.currentMonthMoment).subtract(1, 'month');
     this.setState({ currentMonthMoment: newMoment });
@@ -188,7 +192,7 @@ export default class Calendar extends Component {
 
   onWeekRowLayout = (event) => {
     if (this.state.rowHeight !== event.nativeEvent.layout.height) {
-	  this.setState({ rowHeight: event.nativeEvent.layout.height });
+      this.setState({ rowHeight: event.nativeEvent.layout.height });
     }
   }
 
@@ -221,27 +225,27 @@ export default class Calendar extends Component {
       ? disabledDatesMap[argMoment.startOf('month').format()]
       : null;
 
+    const minDate = moment(this.props.minDate);
+    const maxDate =  moment(this.props.maxDate);
 
     do {
       const dayIndex = renderIndex - offset;
       const isoWeekday = (renderIndex + weekStart) % 7;
+      const currentDate = moment(startOfArgMonthMoment).set('date', dayIndex + 1);
 
       if (dayIndex >= 0 && dayIndex < argMonthDaysCount) {
-        if(moment(startOfArgMonthMoment).set('date', dayIndex + 1).isAfter(moment(this.props.minDate))
-            && moment(startOfArgMonthMoment).set('date', dayIndex + 1).isBefore(moment(this.props.maxDate)))
+        if(currentDate.isBetween(minDate, maxDate, 'day', '[]'))
         {
-          if(!this.props.disabledDays.includes(isoWeekday) && (!disabledDates || (disabledDates && !disabledDates[dayIndex])) )
+          const dayDisabled = this.props.disabledDays.includes(isoWeekday);
+          const dateDisabled = !!(disabledDates && disabledDates[dayIndex]);
+          if( !dayDisabled && !dateDisabled )
           {
             days.push((
               <Day
                 startOfMonth={startOfArgMonthMoment}
                 key={`${renderIndex}`}
-                onPress={() => {
-                  this.selectDate(moment(startOfArgMonthMoment).set('date', dayIndex + 1));
-                }}
-                onLongPress={ () => {
-                  this.props.onLongPress(moment(startOfArgMonthMoment).set('date', dayIndex + 1).format());
-                }}
+                onPress={() => this.selectDate(currentDate)}
+                onLongPress={() => this.longPress(currentDate)}
                 caption={`${dayIndex + 1}`}
                 isToday={argMonthIsToday && (dayIndex === todayIndex)}
                 isSelected={selectedMonthIsArg && (dayIndex === selectedIndex)}
@@ -251,23 +255,23 @@ export default class Calendar extends Component {
               />
             ));
           } else {
-            days.push(<Day 
-                        key={`${renderIndex}`} 
+            days.push(<Day
+                        key={`${renderIndex}`}
                         caption={`${dayIndex + 1}`}
                         isToday={argMonthIsToday && (dayIndex === todayIndex)}
                         showEventIndicators={this.props.showEventIndicators}
-                        disabled 
-                        customStyle={this.props.customStyle} 
+                        disabled
+                        customStyle={this.props.customStyle}
                         />);
           }
         } else {
-           days.push(<Day 
-                        key={`${renderIndex}`} 
+           days.push(<Day
+                        key={`${renderIndex}`}
                         caption={`${dayIndex + 1}`}
                         isToday={argMonthIsToday && (dayIndex === todayIndex)}
                         showEventIndicators={this.props.showEventIndicators}
-                        disabled 
-                        customStyle={this.props.customStyle} 
+                        disabled
+                        customStyle={this.props.customStyle}
                         />);
         }
       } else {
@@ -327,7 +331,7 @@ export default class Calendar extends Component {
             </Text>
           </TouchableOpacity>
           <Text style={[styles.title, this.props.customStyle.title]}>
-        	{this.state.currentMonthMoment.format(this.props.titleFormat)}
+            {this.state.currentMonthMoment.format(this.props.titleFormat)}
           </Text>
           <TouchableOpacity
             style={[styles.controlButton, this.props.customStyle.controlButton]}
@@ -342,7 +346,7 @@ export default class Calendar extends Component {
     : (
       <View style={[styles.calendarControls, this.props.customStyle.calendarControls]}>
         <Text style={[styles.title, this.props.customStyle.title]}>
-        	{this.state.currentMonthMoment.format(this.props.titleFormat)}
+          {this.state.currentMonthMoment.format(this.props.titleFormat)}
         </Text>
       </View>
     );
@@ -351,7 +355,7 @@ export default class Calendar extends Component {
   render() {
     const calendarDates = this.getMonthStack(this.state.currentMonthMoment);
     const eventDatesMap = this.prepareEventDates(this.props.eventDates, this.props.events);
-    const numOfWeeks = getNumberOfWeeks(this.state.currentMonthMoment); 
+    const numOfWeeks = getNumberOfWeeks(this.state.currentMonthMoment);
     const disabledDatesMap = this.prepareDisabledDates(this.props.disabledDates);
 
     return (
@@ -369,9 +373,9 @@ export default class Calendar extends Component {
             showsHorizontalScrollIndicator={false}
             automaticallyAdjustContentInsets
             onMomentumScrollEnd={(event) => this.scrollEnded(event)}
-            style={{ 
-			   height: this.state.rowHeight ? this.state.rowHeight * numOfWeeks : null, 
-			}}
+            style={{
+              height: this.state.rowHeight ? this.state.rowHeight * numOfWeeks : null,
+            }}
           >
             {calendarDates.map((date) => this.renderMonthView(moment(date), eventDatesMap, disabledDatesMap))}
           </ScrollView>

--- a/components/Day.js
+++ b/components/Day.js
@@ -17,15 +17,16 @@ export default class Day extends Component {
     caption: PropTypes.any,
     customStyle: PropTypes.object,
     filler: PropTypes.bool,
+    disabled: PropTypes.bool,
     event: PropTypes.object,
     isSelected: PropTypes.bool,
     isToday: PropTypes.bool,
-    isWeekend: PropTypes.bool,
     onPress: PropTypes.func,
+    onLongPress: PropTypes.func,
     showEventIndicators: PropTypes.bool,
   }
 
-  dayCircleStyle = (isWeekend, isSelected, isToday, event) => {
+  dayCircleStyle = (isSelected, isToday, event) => {
     const { customStyle } = this.props;
     const dayCircleStyle = [styles.dayCircleFiller, customStyle.dayCircleFiller];
 
@@ -44,10 +45,11 @@ export default class Day extends Component {
         dayCircleStyle.push(styles.hasEventCircle, customStyle.hasEventCircle, event.hasEventCircle);
       }
     }
+
     return dayCircleStyle;
   }
 
-  dayTextStyle = (isWeekend, isSelected, isToday, event) => {
+  dayTextStyle = (isDisabled, isSelected, isToday, event) => {
     const { customStyle } = this.props;
     const dayTextStyle = [styles.day, customStyle.day];
 
@@ -55,8 +57,8 @@ export default class Day extends Component {
       dayTextStyle.push(styles.currentDayText, customStyle.currentDayText);
     } else if (isToday || isSelected) {
       dayTextStyle.push(styles.selectedDayText, customStyle.selectedDayText);
-    } else if (isWeekend) {
-      dayTextStyle.push(styles.weekendDayText, customStyle.weekendDayText);
+    } else if (isDisabled) {
+      dayTextStyle.push(styles.disabledDayText, customStyle.disabledDayText);
     }
 
     if (event) {
@@ -69,38 +71,62 @@ export default class Day extends Component {
     let { caption, customStyle } = this.props;
     const {
       filler,
+      disabled,
       event,
-      isWeekend,
       isSelected,
       isToday,
       showEventIndicators,
     } = this.props;
 
-    return filler
-    ? (
+    if(filler) {
+      return (
         <TouchableWithoutFeedback>
           <View style={[styles.dayButtonFiller, customStyle.dayButtonFiller]}>
             <Text style={[styles.day, customStyle.day]} />
           </View>
         </TouchableWithoutFeedback>
-      )
-    : (
-      <TouchableOpacity onPress={this.props.onPress}>
-        <View style={[styles.dayButton, customStyle.dayButton]}>
-          <View style={this.dayCircleStyle(isWeekend, isSelected, isToday, event)}>
-            <Text style={this.dayTextStyle(isWeekend, isSelected, isToday, event)}>{caption}</Text>
-          </View>
-          {showEventIndicators &&
-            <View style={[
-              styles.eventIndicatorFiller,
-              customStyle.eventIndicatorFiller,
-              event && styles.eventIndicator,
-              event && customStyle.eventIndicator,
-              event && event.eventIndicator]}
-            />
-          }
-        </View>
-      </TouchableOpacity>
-    );
+      );
+    } else {
+      if(disabled) {
+        return (
+          <View style={[styles.dayButton, customStyle.dayButton]}>
+            <View style={this.dayCircleStyle(isSelected, isToday, event)}>
+              <Text style={this.dayTextStyle(disabled, isSelected, isToday, event)}>{caption}</Text>
+            </View>
+            {showEventIndicators &&
+              <View style={[
+                styles.eventIndicatorFiller,
+                customStyle.eventIndicatorFiller,
+                event && styles.eventIndicator,
+                event && customStyle.eventIndicator,
+                event && event.eventIndicator]}
+              />
+            }
+            </View>
+        );
+      } else {
+        return (
+         <TouchableOpacity 
+          onPress={this.props.onPress}
+          onLongPress={this.props.onLongPress}>
+          <View style={[styles.dayButton, customStyle.dayButton]}>
+            <View style={this.dayCircleStyle(isSelected, isToday, event)}>
+              <Text style={this.dayTextStyle(disabled, isSelected, isToday, event)}>{caption}</Text>
+            </View>
+            {showEventIndicators &&
+              <View style={[
+                styles.eventIndicatorFiller,
+                customStyle.eventIndicatorFiller,
+                event && styles.eventIndicator,
+                event && customStyle.eventIndicator,
+                event && event.eventIndicator]}
+              />
+            }
+            </View>
+          </TouchableOpacity>
+        );
+      }
+    }
+    
   }
 }

--- a/components/Day.js
+++ b/components/Day.js
@@ -53,12 +53,12 @@ export default class Day extends Component {
     const { customStyle } = this.props;
     const dayTextStyle = [styles.day, customStyle.day];
 
-    if (isToday && !isSelected) {
+    if (isDisabled) {
+      dayTextStyle.push(styles.disabledDayText, customStyle.disabledDayText);
+    } else if (isToday && !isSelected) {
       dayTextStyle.push(styles.currentDayText, customStyle.currentDayText);
     } else if (isToday || isSelected) {
       dayTextStyle.push(styles.selectedDayText, customStyle.selectedDayText);
-    } else if (isDisabled) {
-      dayTextStyle.push(styles.disabledDayText, customStyle.disabledDayText);
     }
 
     if (event) {
@@ -80,11 +80,9 @@ export default class Day extends Component {
 
     if(filler) {
       return (
-        <TouchableWithoutFeedback>
-          <View style={[styles.dayButtonFiller, customStyle.dayButtonFiller]}>
-            <Text style={[styles.day, customStyle.day]} />
-          </View>
-        </TouchableWithoutFeedback>
+        <View style={[styles.dayButtonFiller, customStyle.dayButtonFiller]}>
+          <Text style={[styles.day, customStyle.day]} />
+        </View>
       );
     } else {
       if(disabled) {
@@ -106,27 +104,25 @@ export default class Day extends Component {
         );
       } else {
         return (
-         <TouchableOpacity 
+         <TouchableOpacity
           onPress={this.props.onPress}
-          onLongPress={this.props.onLongPress}>
-          <View style={[styles.dayButton, customStyle.dayButton]}>
-            <View style={this.dayCircleStyle(isSelected, isToday, event)}>
-              <Text style={this.dayTextStyle(disabled, isSelected, isToday, event)}>{caption}</Text>
-            </View>
-            {showEventIndicators &&
-              <View style={[
-                styles.eventIndicatorFiller,
-                customStyle.eventIndicatorFiller,
-                event && styles.eventIndicator,
-                event && customStyle.eventIndicator,
-                event && event.eventIndicator]}
-              />
-            }
-            </View>
+          onLongPress={this.props.onLongPress}
+          style={[styles.dayButton, customStyle.dayButton]}>
+          <View style={this.dayCircleStyle(isSelected, isToday, event)}>
+            <Text style={this.dayTextStyle(disabled, isSelected, isToday, event)}>{caption}</Text>
+          </View>
+          {showEventIndicators &&
+            <View style={[
+              styles.eventIndicatorFiller,
+              customStyle.eventIndicatorFiller,
+              event && styles.eventIndicator,
+              event && customStyle.eventIndicator,
+              event && event.eventIndicator]}
+            />
+          }
           </TouchableOpacity>
         );
       }
     }
-    
   }
 }

--- a/components/styles.js
+++ b/components/styles.js
@@ -96,7 +96,7 @@ const styles = StyleSheet.create({
     color: 'white',
     fontWeight: 'bold',
   },
-  weekendDayText: {
+  disabledDayText: {
     color: '#cccccc',
   },
 });


### PR DESCRIPTION
This combines @daniel-dll's PR #97 and #98. I also fixed the following:

- isBefore / isAfter not catching same day. Needed to be at least isSameOrBefore or isSameOrAfter with `'day'` resolution option. Accomplished this with a single isBetween call w/ `[]` matching option.
- onLongPress was being called regardless if it was defined or not. Added check for this.
- Daniel removed weekend, but left the style. Renamed it to disabled so disabled days show grayed out by default.
- Made disabled style superseded today & selected. If a disabled date was today, it wasn't showing as such.
- Fixed spacing issues

I personally don't need the weekend option, but I understand if you want to add the back. I just merged in Daniel's two PR's and fixed bugs (needed the styling options for disabled days).