### PR TITLE
Use container width instead of device width

### DIFF
--- a/components/Day.js
+++ b/components/Day.js
@@ -23,6 +23,8 @@ export default class Day extends Component {
     isWeekend: PropTypes.bool,
     onPress: PropTypes.func,
     showEventIndicators: PropTypes.bool,
+    width: PropTypes.number,
+    height: PropTypes.number,
   }
 
   dayCircleStyle = (isWeekend, isSelected, isToday, event) => {
@@ -74,19 +76,19 @@ export default class Day extends Component {
       isSelected,
       isToday,
       showEventIndicators,
+      width,
+      height
     } = this.props;
-
-    return filler
-    ? (
-        <TouchableWithoutFeedback>
-          <View style={[styles.dayButtonFiller, customStyle.dayButtonFiller]}>
-            <Text style={[styles.day, customStyle.day]} />
-          </View>
-        </TouchableWithoutFeedback>
-      )
-    : (
-      <TouchableOpacity onPress={this.props.onPress}>
-        <View style={[styles.dayButton, customStyle.dayButton]}>
+    const size = {width, height};
+    if(filler) {
+      return (
+        <View style={[styles.dayButtonFiller, size, customStyle.dayButtonFiller]}>
+          <Text style={[styles.day, customStyle.day]} />
+        </View>
+      );
+    } else {
+      return (
+        <TouchableOpacity onPress={this.props.onPress} style={[styles.dayButton, size, customStyle.dayButton]}>
           <View style={this.dayCircleStyle(isWeekend, isSelected, isToday, event)}>
             <Text style={this.dayTextStyle(isWeekend, isSelected, isToday, event)}>{caption}</Text>
           </View>
@@ -96,11 +98,10 @@ export default class Day extends Component {
               customStyle.eventIndicatorFiller,
               event && styles.eventIndicator,
               event && customStyle.eventIndicator,
-              event && event.eventIndicator]}
-            />
+              event && event.eventIndicator]} />
           }
-        </View>
-      </TouchableOpacity>
-    );
+        </TouchableOpacity>
+      );
+    }
   }
 }

--- a/components/styles.js
+++ b/components/styles.js
@@ -1,13 +1,11 @@
 import { Dimensions, StyleSheet } from 'react-native';
 
-const DEVICE_WIDTH = Dimensions.get('window').width;
-
 const styles = StyleSheet.create({
   calendarContainer: {
     backgroundColor: '#f7f7f7',
   },
   monthContainer: {
-    width: DEVICE_WIDTH,
+
   },
   calendarControls: {
     flexDirection: 'row',
@@ -47,14 +45,12 @@ const styles = StyleSheet.create({
   },
   dayButton: {
     alignItems: 'center',
-    padding: 5,
-    width: DEVICE_WIDTH / 7,
+    justifyContent: 'center',
     borderTopWidth: 1,
     borderTopColor: '#e9e9e9',
   },
   dayButtonFiller: {
-    padding: 5,
-    width: DEVICE_WIDTH / 7,
+
   },
   day: {
     fontSize: 16,


### PR DESCRIPTION
Currently the device width is used to calculate the width of the calendar, and then each day is /7 of that width. This is a problem on tablets that have large screens. You more than likely will want to reduce the size of the calendar to be less than the width of the screen, especially in landscape.

The following patch uses `onLayout` to figure out the width of the parent container and uses that instead of the device width. It then uses that /7 to for the day width. I had used `flex:1` for the day width, but I also wanted the height to match the width - that way each day doesn't end up being a narrow rectangle depending on the container width.

I also fixed a bug where it would always select the current day, even though `this.props.selectedDate` is undefined. This happened because `moment(undefined)` returns the current date.

This patch also makes it easier to do 2 months side-by-side down the road. To do that you would likely: divide `containerWidth` by 2, update `getMonthStack` to render more months, and change the scroll functions to take 2 months into account.