### PR TITLE
Weekly view should only show 1 row of dates.

### DIFF
--- a/components/Calendar.js
+++ b/components/Calendar.js
@@ -344,7 +344,8 @@ export default class Calendar extends Component {
   render() {
     const calendarDates = this.getStack(this.state.currentMoment);
     const eventDatesMap = this.prepareEventDates(this.props.eventDates, this.props.events);
-    const numOfWeeks = getNumberOfWeeks(this.state.currentMonthMoment, this.props.weekStart);
+    const numOfWeeks = this.props.calendarFormat === 'weekly' ? 1 :
+      getNumberOfWeeks(this.state.currentMonthMoment, this.props.weekStart);
 
     return (
       <View style={[styles.calendarContainer, this.props.customStyle.calendarContainer]}>


### PR DESCRIPTION
Problem: if set `scrollEnabled`, the height of calendar will be set as the same as monthly.

![b7zumxncsz](https://cloud.githubusercontent.com/assets/14301745/26285534/d9e5667a-3e06-11e7-9198-c08388c08622.gif)
