### PR TITLE
Fix bug with calculating number of weeks not using the current month

### DIFF
--- a/components/Calendar.js
+++ b/components/Calendar.js
@@ -358,7 +358,7 @@ export default class Calendar extends Component {
     const calendarDates = this.getStack(this.state.currentMoment);
     const eventDatesMap = this.prepareEventDates(this.props.eventDates, this.props.events);
     const numOfWeeks = this.props.calendarFormat === 'weekly' ? 1 :
-      getNumberOfWeeks(this.state.currentMonthMoment, this.props.weekStart);
+      getNumberOfWeeks(this.state.currentMoment, this.props.weekStart);
 
     return (
       <View style={[styles.calendarContainer, this.props.customStyle.calendarContainer]}>


### PR DESCRIPTION
This bug is introduced in the new feature `Weekly View`. The calculation of number of weeks rely on the current moment now instead of currentMonthMoment, but the corresponding change is missing. This should fix the issue.