### PR TITLE
Import PropTypes from standalone package

### DIFF
--- a/components/Calendar.js
+++ b/components/Calendar.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import {
   Dimensions,
   ScrollView,
@@ -6,6 +6,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
+import PropTypes from 'prop-types';
 
 import Day from './Day';
 

--- a/components/Day.js
+++ b/components/Day.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import {
   Text,
   TouchableOpacity,
@@ -7,6 +7,7 @@ import {
   Dimensions,
   StyleSheet,
 } from 'react-native';
+import PropTypes from 'prop-types';
 
 import styles from './styles';
 


### PR DESCRIPTION
We can't build our app using React v16 until this can get merged.

- See note on React 16 release https://reactjs.org/blog/2017/09/26/react-v16.0.html#packaging.
- Fixes #167.