### PR TITLE
Set option to show filler days

### DIFF
--- a/components/Calendar.js
+++ b/components/Calendar.js
@@ -57,7 +57,7 @@ export default class Calendar extends Component {
     selectedDate: PropTypes.any,
     showControls: PropTypes.bool,
     showEventIndicators: PropTypes.bool,
-    showFillerDay: PropTypes.bool,
+    showFillerDays: PropTypes.bool,
     startDate: PropTypes.any,
     titleFormat: PropTypes.string,
     today: PropTypes.any,
@@ -77,7 +77,7 @@ export default class Calendar extends Component {
     scrollEnabled: false,
     showControls: false,
     showEventIndicators: false,
-    showFillerDay: false,
+    showFillerDays: false,
     startDate: moment().format('YYYY-MM-DD'),
     titleFormat: 'MMMM YYYY',
     weekStart: 1,
@@ -282,7 +282,7 @@ export default class Calendar extends Component {
             filler: true,
             customStyle: this.props.customStyle,
             caption: thisMoment.format('D'),
-            showFillerDay: this.props.showFillerDay,
+            showFillerDays: this.props.showFillerDays,
             showEventIndicators: this.props.showEventIndicators,
           })
         );

--- a/components/Calendar.js
+++ b/components/Calendar.js
@@ -57,6 +57,7 @@ export default class Calendar extends Component {
     selectedDate: PropTypes.any,
     showControls: PropTypes.bool,
     showEventIndicators: PropTypes.bool,
+    showFillerDay: PropTypes.bool,
     startDate: PropTypes.any,
     titleFormat: PropTypes.string,
     today: PropTypes.any,
@@ -76,6 +77,7 @@ export default class Calendar extends Component {
     scrollEnabled: false,
     showControls: false,
     showEventIndicators: false,
+    showFillerDay: false,
     startDate: moment().format('YYYY-MM-DD'),
     titleFormat: 'MMMM YYYY',
     weekStart: 1,
@@ -279,6 +281,9 @@ export default class Calendar extends Component {
             key: renderIndex,
             filler: true,
             customStyle: this.props.customStyle,
+            caption: thisMoment.format('D'),
+            showFillerDay: this.props.showFillerDay,
+            showEventIndicators: this.props.showEventIndicators,
           })
         );
       }

--- a/components/Day.js
+++ b/components/Day.js
@@ -27,6 +27,7 @@ export default class Day extends Component {
     onPress: PropTypes.func,
     onLongPress: PropTypes.func,
     showEventIndicators: PropTypes.bool,
+    showFillerDay: PropTypes.bool,
   }
 
   dayCircleStyle = (isWeekend, isSelected, isToday, event) => {
@@ -90,6 +91,7 @@ export default class Day extends Component {
     let { caption, customStyle } = this.props;
     const {
       filler,
+      showFillerDay,
       event,
       isWeekend,
       isSelected,
@@ -105,11 +107,20 @@ export default class Day extends Component {
       dayButtonFillerStyle = [styles.dayButtonFiller, customStyle.dayButtonFiller, {width: dayWidth}];
     }
 
+    if (showFillerDay) {
+      dayButtonFillerStyle.unshift(styles.dayButton);
+    }
+
     return filler
       ? (
         <TouchableWithoutFeedback>
           <View style={dayButtonFillerStyle}>
-            <Text style={[styles.day, customStyle.day]} />
+            {showFillerDay &&
+            <Text style={[styles.day, styles.fillerDay, customStyle.fillerDay]}>
+              {caption}
+            </Text>
+            }
+            {showEventIndicators && <View style={styles.eventIndicatorFiller}/>}
           </View>
         </TouchableWithoutFeedback>
       )

--- a/components/Day.js
+++ b/components/Day.js
@@ -27,7 +27,7 @@ export default class Day extends Component {
     onPress: PropTypes.func,
     onLongPress: PropTypes.func,
     showEventIndicators: PropTypes.bool,
-    showFillerDay: PropTypes.bool,
+    showFillerDays: PropTypes.bool,
   }
 
   dayCircleStyle = (isWeekend, isSelected, isToday, event) => {
@@ -91,7 +91,7 @@ export default class Day extends Component {
     let { caption, customStyle } = this.props;
     const {
       filler,
-      showFillerDay,
+      showFillerDays,
       event,
       isWeekend,
       isSelected,
@@ -107,7 +107,7 @@ export default class Day extends Component {
       dayButtonFillerStyle = [styles.dayButtonFiller, customStyle.dayButtonFiller, {width: dayWidth}];
     }
 
-    if (showFillerDay) {
+    if (showFillerDays) {
       dayButtonFillerStyle.unshift(styles.dayButton);
     }
 
@@ -115,7 +115,7 @@ export default class Day extends Component {
       ? (
         <TouchableWithoutFeedback>
           <View style={dayButtonFillerStyle}>
-            {showFillerDay &&
+            {showFillerDays &&
             <Text style={[styles.day, styles.fillerDay, customStyle.fillerDay]}>
               {caption}
             </Text>

--- a/components/styles.js
+++ b/components/styles.js
@@ -61,6 +61,9 @@ const styles = StyleSheet.create({
     fontSize: 16,
     alignSelf: 'center',
   },
+  fillerDay: {
+    color: '#cccccc',
+  },
   eventIndicatorFiller: {
     marginTop: 3,
     borderColor: 'transparent',

--- a/example/App.js
+++ b/example/App.js
@@ -56,7 +56,7 @@ class App extends Component {
       <View style={styles.container}>
         <Calendar
           ref="calendar"
-          showFillerDay
+          showFillerDays
           eventDates={eventDates}
           scrollEnabled
           showControls

--- a/example/App.js
+++ b/example/App.js
@@ -56,6 +56,7 @@ class App extends Component {
       <View style={styles.container}>
         <Calendar
           ref="calendar"
+          showFillerDay
           eventDates={eventDates}
           scrollEnabled
           showControls
@@ -71,7 +72,7 @@ class App extends Component {
           onSwipePrev={(e) => console.log('onSwipePrev: ', e)}
           onSwipeNext={(e) => console.log('onSwipeNext', e)}
           selectedDate={this.state.selectedDate}
-          showEventIndicators={true}
+          showEventIndicators
         />
         <Text>Selected Date: {moment(this.state.selectedDate).format('MMMM DD YYYY')}</Text>
       </View>


### PR DESCRIPTION
Allow to have an option to show days of the previous and next month in current month. I need it and implemented this to use in my app. I'm also seeing there's a feature request in https://github.com/christopherdro/react-native-calendar/issues/100.